### PR TITLE
Add destination port extension

### DIFF
--- a/src/hashdict_flow.h
+++ b/src/hashdict_flow.h
@@ -18,6 +18,7 @@ typedef struct keynode_flow keynode_flow;
 typedef struct dos_counter dos_counter;
 typedef struct dictionary_flow_key dictionary_flow_key;
 
+// data = src_ia || dst_port
 struct dictionary_flow_key {
 	char data[10];
 };

--- a/src/hashdict_flow.h
+++ b/src/hashdict_flow.h
@@ -27,7 +27,7 @@ struct dos_counter {
 
 struct keynode_flow {
 	struct keynode_flow *next;
-	uint64_t key;
+	char key[10];
 	dos_counter *counters;
 } __rte_cache_aligned;
 
@@ -41,7 +41,8 @@ struct dictionary_flow {
 
 struct dictionary_flow *dic_new_flow(int initial_size);
 void dic_delete_flow(struct dictionary_flow *dic);
-int dic_add_flow(struct dictionary_flow *dic, uint64_t key, dos_counter *value);
-int dic_find_flow(struct dictionary_flow *dic, uint64_t key);
-int dic_remove_flow(struct dictionary_flow *dic, uint64_t key);
+int dic_add_flow(struct dictionary_flow *dic, void *key, dos_counter *value);
+int dic_find_flow(struct dictionary_flow *dic, void *key);
+int dic_remove_flow(struct dictionary_flow *dic, void *key);
+void parse_key(char *dst_key, uint64_t isd_as, uint16_t dst_port);
 #endif

--- a/src/hashdict_flow.h
+++ b/src/hashdict_flow.h
@@ -16,6 +16,11 @@
 typedef struct dictionary_flow dictionary_flow;
 typedef struct keynode_flow keynode_flow;
 typedef struct dos_counter dos_counter;
+typedef struct dictionary_flow_key dictionary_flow_key;
+
+struct dictionary_flow_key {
+	char data[10];
+};
 
 /* dos counter struct */
 struct dos_counter {
@@ -27,7 +32,7 @@ struct dos_counter {
 
 struct keynode_flow {
 	struct keynode_flow *next;
-	char key[10];
+	dictionary_flow_key *key;
 	dos_counter *counters;
 } __rte_cache_aligned;
 
@@ -41,8 +46,7 @@ struct dictionary_flow {
 
 struct dictionary_flow *dic_new_flow(int initial_size);
 void dic_delete_flow(struct dictionary_flow *dic);
-int dic_add_flow(struct dictionary_flow *dic, void *key, dos_counter *value);
-int dic_find_flow(struct dictionary_flow *dic, void *key);
-int dic_remove_flow(struct dictionary_flow *dic, void *key);
-void parse_key(char *dst_key, uint64_t isd_as, uint16_t dst_port);
+int dic_add_flow(struct dictionary_flow *dic, dictionary_flow_key *key, dos_counter *value);
+int dic_find_flow(struct dictionary_flow *dic, dictionary_flow_key *key);
+int dic_remove_flow(struct dictionary_flow *dic, dictionary_flow_key *key);
 #endif

--- a/src/lf_config.h
+++ b/src/lf_config.h
@@ -14,6 +14,7 @@ struct lf_config_peer {
 	uint32_t public_addr; /* in network byte order */
 	uint64_t rate_limit;
 	uint8_t ether_addr[6];
+	uint16_t dst_port;
 };
 
 struct lf_config {

--- a/src/lib/drkey/go.mod
+++ b/src/lib/drkey/go.mod
@@ -4,4 +4,4 @@ go 1.16
 
 require github.com/scionproto/scion v0.0.0-00010101000000-000000000000
 
-replace github.com/scionproto/scion => /home/scion/scion
+replace github.com/scionproto/scion => /home/ubuntu/scion

--- a/src/lib/drkey/go.mod
+++ b/src/lib/drkey/go.mod
@@ -4,4 +4,4 @@ go 1.16
 
 require github.com/scionproto/scion v0.0.0-00010101000000-000000000000
 
-replace github.com/scionproto/scion => /home/ubuntu/scion
+replace github.com/scionproto/scion => /home/scion/scion

--- a/src/scionfwd.c
+++ b/src/scionfwd.c
@@ -172,6 +172,8 @@ static uint16_t nb_txd = RTE_TEST_TX_DESC_DEFAULT;
  * SCION Headers
  */
 
+#define SCION_PROTOCOL_DL_SL_MASK 0x33
+
 #define SCION_PROTOCOL_HBH 200
 #define SCION_PROTOCOL_E2E 201
 
@@ -941,11 +943,10 @@ static int handle_inbound_scion_pkt(struct rte_mbuf *m, struct rte_ether_hdr *et
 			}
 #endif
 
-			if (unlikely(scion_cmn_hdr->dt_dl_st_sl != 0)) {
+			if (unlikely((scion_cmn_hdr->dt_dl_st_sl & SCION_PROTOCOL_DL_SL_MASK) != 0)) {
 				// #if LOG_PACKETS
 				printf(
-					"[%d] Not yet implemented: SCION packet contains unsupported host-address "
-					"types/lengths.\n",
+					"[%d] Not yet implemented: SCION packet contains unsupported host-address lengths.\n",
 					lcore_id);
 				// #endif
 				return -1;
@@ -1377,11 +1378,10 @@ static int handle_outbound_scion_pkt(struct rte_mbuf *m, struct rte_ether_hdr *e
 				}
 #endif
 
-				if (unlikely(scion_cmn_hdr->dt_dl_st_sl != 0)) {
+				if (unlikely((scion_cmn_hdr->dt_dl_st_sl & SCION_PROTOCOL_DL_SL_MASK) != 0)) {
 					// #if LOG_PACKETS
 					printf(
-						"[%d] Not yet implemented: SCION packet contains unsupported host-address "
-						"types/lengths.\n",
+						"[%d] Not yet implemented: SCION packet contains unsupported host-address lengths.\n",
 						lcore_id);
 					// #endif
 					return -1;

--- a/testnet/lf_config_1_ff00_0_111
+++ b/testnet/lf_config_1_ff00_0_111
@@ -4,11 +4,20 @@
 	"peers": [
 		{
 			"isd_as": "0-0",
+			"dst_port": 0,
 			"rate_limit": 9223372036854775807
 		},
 		{
 			"isd_as": "1-ff00:0:112",
 			"public_addr": "10.248.1.1",
+			"dst_port": 10111,
+			"rate_limit": 9223372036854775807,
+			"ether_addr": "00:76:65:74:68:31"
+		},
+		{
+			"isd_as": "1-ff00:0:112",
+			"public_addr": "10.248.1.1",
+			"dst_port": 0,
 			"rate_limit": 9223372036854775807,
 			"ether_addr": "00:76:65:74:68:31"
 		}

--- a/testnet/lf_config_1_ff00_0_112
+++ b/testnet/lf_config_1_ff00_0_112
@@ -4,13 +4,22 @@
 	"peers": [
 		{
 			"isd_as": "0-0",
+			"dst_port": 0,
 			"rate_limit": 9223372036854775807
 		},
 		{
 			"isd_as": "1-ff00:0:111",
 			"public_addr": "10.248.4.1",
+			"dst_port": 10111,
 			"rate_limit": 9223372036854775807,
 			"ether_addr": "00:76:65:74:68:35"
+		},
+		{
+			"isd_as": "1-ff00:0:111",
+			"public_addr": "10.248.1.1",
+			"dst_port": 0,
+			"rate_limit": 9223372036854775807,
+			"ether_addr": "00:76:65:74:68:31"
 		}
 	],
 	"backends": [


### PR DESCRIPTION
This PR contains an extension for the LF implementation that allows rate-limiting based on src_IA and destination port. This PR encompasses the following changes:

- LF extension to map packets to buckets depending on the source AS and the destination port.
- LF configuration parsing is also extended to enable independent rate-limits according to the described idea.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/lightning-filter/4)
<!-- Reviewable:end -->
